### PR TITLE
Debian 10 support

### DIFF
--- a/.github/workflows/molecule-test.yml
+++ b/.github/workflows/molecule-test.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       max-parallel: 4
       matrix:
-        molecule_distro: ['centos7', 'centos8', 'ubuntu1804', 'ubuntu2004']
+        molecule_distro: ['centos7', 'centos8', 'ubuntu1804', 'ubuntu2004', 'debian10']
     env:
       ANSIBLE_CALLBACK_WHITELIST: profile_tasks
 

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ fabric.properties
 
 # Ignore Ansible *.retry files
 *.retry
+
+# Ignore Molecule cache directory
+.cache/

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -4,6 +4,16 @@
   become: true
 
   tasks:
+    - name: Debian | Verify APT repository
+      lineinfile:
+        dest: /etc/apt/sources.list.d/debian_neo4j_com.list
+        line: 'deb https://debian.neo4j.com stable latest'
+      check_mode: true
+      register: apt_repo
+      failed_when: apt_repo.changed
+      when:
+        - ansible_os_family == 'Debian'
+
     - name: Verify that Neo4j is running on port 7474
       uri:
         url: http://127.0.0.1:7474/

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -29,6 +29,10 @@
 
 - name: Add the Neo Technology Debian repository for Neo4j
   apt_repository:
-    repo: "deb https://debian.neo4j.com stable latest"
+    repo: "deb https://debian.neo4j.com stable {% if neo4j_version is defined %}{{ neo4j_version.split('.')[0:2] | join('.') }}{% else %}latest{% endif %}"
     state: present
     update_cache: true
+
+- name: Determine the neo4j package to install
+  set_fact:
+    neo4j_package: neo4j{% if neo4j_edition == 'enterprise' %}-enterprise{% endif %}{% if neo4j_version is defined %}=1:{{ neo4j_version }}{% endif %}

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -13,3 +13,7 @@
     baseurl: https://yum.neo4j.com/stable
     gpgkey: https://debian.neo4j.com/neotechnology.gpg.key
     gpgcheck: true
+
+- name: Determine the neo4j package to install
+  set_fact:
+    neo4j_package: neo4j{% if neo4j_edition == 'enterprise' %}-enterprise{% endif %}{% if neo4j_version is defined %}-{{ neo4j_version }}{% endif %}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,10 +5,6 @@
 - name: Include OS specific tasks
   include_tasks: "{{ ansible_os_family }}.yml"
 
-- name: Determine the neo4j package to install
-  set_fact:
-    neo4j_package: neo4j{% if neo4j_edition == 'enterprise' %}-enterprise{% endif %}{% if neo4j_version is defined %}-{{ neo4j_version }}{% endif %}
-
 - name: Install Neo4j
   package:
     name: "{{ neo4j_package }}"


### PR DESCRIPTION
Thanks for the great package!

I had some issues on Debian 10 because the way the [repository and package names](https://debian.neo4j.com/) are organized is different from the current scheme used, so I moved the package name creation to the OS-specific tasks. I tried creating a second scenario to test providing an explicit package name, but failed. I manually verified that providing a specific version works by setting `neo4j_version` in `converge.yml` and adjusting the (new) test. (Running `MOLECULE_DISTRO=debian10 molecule test`, `neo4j_version` set to `4.2.5`.)